### PR TITLE
Hide warning when rmdir /dgr/builder

### DIFF
--- a/aci-builder/files/dgr/builder/stage2/builder.sh
+++ b/aci-builder/files/dgr/builder/stage2/builder.sh
@@ -116,7 +116,7 @@ if [ -d ${ACI_HOME}/runlevels/build ] || [ -d ${ACI_HOME}/runlevels/build-late ]
 fi
 
 
-rmdir ${ROOTFS}/dgr/builder &> /dev/null || true
+rmdir ${ROOTFS}/dgr/builder >/dev/null 2>&1 || true
 
 if [ "${CATCH_ON_STEP}" == "true" ]; then
     echo_purple "Catch requested dropping to shell at end of build"


### PR DESCRIPTION
Because if directory is not empty then it displays a warning message:

    Attempted to remove disk file system, and we can't allow that.