### PR TITLE
Upgrade the unavailable cdebootstrap-static version 0.7.5 to 0.7.6

### DIFF
--- a/examples/debian/aci-debian/runlevels/builder/10.debootstrap.sh
+++ b/examples/debian/aci-debian/runlevels/builder/10.debootstrap.sh
@@ -4,7 +4,7 @@ set -e
 isLevelEnabled "debug" && set -x
 
 keyringFile=debian-archive-keyring_2014.3_all.deb
-cdebootstrapFile=cdebootstrap-static_0.7.5_amd64.deb
+cdebootstrapFile=cdebootstrap-static_0.7.6_amd64.deb
 gpgvFile=gpgv_1.4.18-7+deb8u3_amd64.deb
 
 mkdir /tmp/debootstrap


### PR DESCRIPTION
Inside the example dgr/examples/debian/aci-debian, the Debian binary package cdebootstrap-static_0.7.5_amd64.deb isn't available:

```
curl -I http://ftp.us.debian.org/debian/pool/main/c/cdebootstrap/cdebootstrap-static_0.7.5_amd64.deb
HTTP/1.1 404 Not Found
```

I replaced it by the latest cdebootstrap-static_0.7.6_amd64.deb:


```
curl -I http://ftp.us.debian.org/debian/pool/main/c/cdebootstrap/cdebootstrap-static_0.7.6_amd64.deb
HTTP/1.1 200 OK

```