### PR TITLE
generalize assumptions about build environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,9 @@ if ! command -v upx >/dev/null; then
 fi
 if ! command -v go-bindata >/dev/null; then
   go get github.com/jteeuwen/go-bindata
-  (cd "$(find ../../../.. -name 'go-bindata' -type d | head -n 1)" && make)
+  (cd "$(find ../../../.. -name 'go-bindata' -type d | head -n 1)" \
+  && sed -i -e '/^check/s: vet::' testdata/Makefile \
+  && make)
 fi
 
 # clean

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,23 @@
 #!/bin/sh
 set -e
 set -x
-start=`date +%s`
-dir=$( dirname $0 )
+start=$( date +%s )
+: ${dir:="$( dirname $0 )"}
 
-[ -f ${GOPATH}/bin/godep ] || go get github.com/tools/godep
-[ -f ${GOPATH}/bin/go-bindata ] || go get github.com/jteeuwen/go-bindata
-[ -f /usr/bin/upx ] || (echo "upx is required to build dgr" && exit 1)
+if ! command -v godep >/dev/null; then
+  go get github.com/tools/godep
+fi
+if ! command -v upx >/dev/null; then
+  >&2 echo "upx is required to build dgr"
+  >&2 echo "You can get it from: https://github.com/upx/upx/releases"
+  exit 1
+fi
+if ! command -v go-bindata >/dev/null; then
+  go get github.com/jteeuwen/go-bindata
+  set -o pipefail
+  (cd "$(find ../../../.. -name 'go-bindata' -type d | head -n 1)" && make)
+  set +o pipefail
+fi
 
 # clean
 rm -Rf ${dir}/dist/*-amd64
@@ -25,7 +36,6 @@ mkdir -p ${dir}/dist/bindata/aci/blablacar.github.io/dgr
 [ -f ${dir}/dist/bindata/aci-builder.aci ] || ${dir}/aci-builder/build.sh
 
 # binary
-[ -f ${GOPATH}/bin/go-bindata ] || go get -u github.com/jteeuwen/go-bindata/...
 go-bindata -nomemcopy -pkg dist -o ${dir}/dist/bindata.go ${dir}/dist/bindata/...
 
 echo -e "\033[0;32mBuilding dgr\033[0m\n"
@@ -45,7 +55,7 @@ upx ${dir}/dist/linux-amd64/dgr
 godep go test -cover ${dir}/bin-dgr/... ${dir}/bin-templater/... ${dir}/aci-builder/... ${dir}/aci-tester/...
 
 # install
-cp ${dir}/dist/linux-amd64/dgr ${GOPATH}/bin/dgr
+cp ${dir}/dist/linux-amd64/dgr ${dir}/../../../../bin/dgr
 
 end=`date +%s`
 echo "Duration : $((end-start))s"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
-#!/bin/sh
-set -e
-set -x
+#!/bin/bash
+set -euxo pipefail
 start=$( date +%s )
 : ${dir:="$( dirname $0 )"}
 
@@ -14,9 +13,7 @@ if ! command -v upx >/dev/null; then
 fi
 if ! command -v go-bindata >/dev/null; then
   go get github.com/jteeuwen/go-bindata
-  set -o pipefail
   (cd "$(find ../../../.. -name 'go-bindata' -type d | head -n 1)" && make)
-  set +o pipefail
 fi
 
 # clean
@@ -40,9 +37,7 @@ go-bindata -nomemcopy -pkg dist -o ${dir}/dist/bindata.go ${dir}/dist/bindata/..
 
 echo -e "\033[0;32mBuilding dgr\033[0m\n"
 
-if [ -z ${VERSION} ]; then
-    VERSION=0
-fi
+: ${VERSION:=0}
 
 # build
 GOOS=linux GOARCH=amd64 godep go build --ldflags "-s -w -X main.buildDate=`date -u '+%Y-%m-%d_%H:%M'` \

--- a/quality.sh
+++ b/quality.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
-start=`date +%s`
-dir=$( dirname "$0" )
+start=$(date +%s)
+: ${dir:="$( dirname $0 )"}
 
 go_files=`find . -name '*.go' 2> /dev/null | grep -v dist/ | grep -v vendor/ | grep -v .git`
 
@@ -12,11 +12,12 @@ echo -e "\033[0;32mFix\033[0m"
 go tool fix ${go_files}
 
 echo -e "\033[0;32mErr check\033[0m"
-[ -f ${GOPATH}/bin/errcheck ] || go get -u github.com/kisielk/errcheck
+
+command -v errcheck >/dev/null || go get -u github.com/kisielk/errcheck
 errcheck ./... | grep -v vendor
 
 echo -e "\033[0;32mLint\033[0m"
-[ -f ${GOPATH}/bin/golint ] || go get -u github.com/golang/lint/golint
+command -v golint >/dev/null || go get -u github.com/golang/lint/golint
 for i in ${go_files}; do
     golint ${i}
 done
@@ -25,17 +26,17 @@ echo -e "\033[0;32mVet\033[0m"
 go tool vet ${go_files} || true
 
 echo -e "\033[0;32mMisspell\033[0m"
-[ -f ${GOPATH}/bin/misspell ] || go get -u github.com/client9/misspell/cmd/misspell
+command -v misspell >/dev/null || go get -u github.com/client9/misspell/cmd/misspell
 misspell -source=text ${go_files}
 
 echo -e "\033[0;32mIneffassign\033[0m"
-[ -f ${GOPATH}/bin/ineffassign ] || go get -u github.com/gordonklaus/ineffassign
+command -v ineffassign >/dev/null || go get -u github.com/gordonklaus/ineffassign
 for i in ${go_files}; do
     ineffassign -n ${i} || true
 done
 
 echo -e "\033[0;32mGocyclo\033[0m"
-[ -f ${GOPATH}/bin/gocyclo ] || go get -u github.com/fzipp/gocyclo
+command -v gocyclo || go get -u github.com/fzipp/gocyclo
 gocyclo -over 15 ${go_files} || true
 
 echo "Quality duration : $((`date +%s`-start))s"


### PR DESCRIPTION
The provided scripts have been written with a specific layout and assumptions about how and where binaries are installed in mind. These patches attempt to generalize for slightly different environments.