### PR TITLE
use curl only - replace any wget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ go:
 install:
   - sudo rm -rf /var/lib/apt/lists/*
   - sudo add-apt-repository ppa:duggan/bats --yes
+  - curl -fsS --next file:///etc/os-release &>/dev/null || sudo add-apt-repository ppa:costamagnagianfranco/ettercap-stable-backports --yes
   - sudo apt-get update -qq
-  - sudo apt-get install -qq upx
+  - sudo apt-get install -qq upx curl
   - sudo ./scripts/travis-install-rkt.sh
   - sudo apt-get install -qq bats
 

--- a/aci-tester/build.sh
+++ b/aci-tester/build.sh
@@ -11,11 +11,22 @@ mkdir -p ${rootfs}/dgr/usr/bin ${rootfs}/dgr/usr/lib
 cp -R ${dir}/files/. ${rootfs}/
 cp ${dir}/manifest.json ${target}/manifest
 
-wget -O ${rootfs}/dgr/usr/bin/bats https://raw.githubusercontent.com/sstephenson/bats/master/libexec/bats
-wget -O ${rootfs}/dgr/usr/bin/bats-exec-suite https://raw.githubusercontent.com/sstephenson/bats/master/libexec/bats-exec-suite
-wget -O ${rootfs}/dgr/usr/bin/bats-exec-test https://raw.githubusercontent.com/sstephenson/bats/master/libexec/bats-exec-test
-wget -O ${rootfs}/dgr/usr/bin/bats-format-tap-stream https://raw.githubusercontent.com/sstephenson/bats/master/libexec/bats-format-tap-stream
-wget -O ${rootfs}/dgr/usr/bin/bats-preprocess https://raw.githubusercontent.com/sstephenson/bats/master/libexec/bats-preprocess
+: ${bats_src:="https://raw.githubusercontent.com/sstephenson/bats/master/libexec"}
+curl --fail --silent --show-error --location --remote-time --compressed --create-dirs \
+    {-z,-o}"${rootfs}/dgr/usr/bin/bats" \
+    ${bats_src}/bats \
+  --next \
+    {-z,-o}"${rootfs}/dgr/usr/bin/bats-exec-suite" \
+    ${bats_src}/bats-exec-suite \
+  --next \
+    {-z,-o}"${rootfs}/dgr/usr/bin/bats-exec-test" \
+    ${bats_src}/bats-exec-test \
+  --next \
+    {-z,-o}"${rootfs}/dgr/usr/bin/bats-format-tap-stream" \
+    ${bats_src}/bats-format-tap-stream \
+  --next \
+    {-z,-o}"${rootfs}/dgr/usr/bin/bats-preprocess" \
+    ${bats_src}/bats-preprocess
 
 chmod +x ${rootfs}/dgr/usr/bin/*
 

--- a/gomake
+++ b/gomake
@@ -71,7 +71,9 @@ err_count() {
 
 gomake_update() {
     echo_green "Downloading gomake"
-    wget -q -O ${work_path}/gomake.tmp https://raw.githubusercontent.com/n0rad/gomake/master/gomake
+    curl --fail --silent --show-error --location --remote-time --compressed \
+        -o ${work_path}/gomake.tmp \
+        https://raw.githubusercontent.com/n0rad/gomake/master/gomake
     chmod +x ${work_path}/gomake.tmp
     mv ${work_path}/gomake.tmp ${work_path}/$0
 }

--- a/scripts/dgr-update.sh
+++ b/scripts/dgr-update.sh
@@ -29,8 +29,7 @@ if [ -f "$dir/.last_dgr" ]; then
 fi
 
 if [ "$version" != "$last_dgr" ]; then
-	wget -O ${dir}/dgr.tar.gz $url
-	tar xvzf ${dir}/dgr.tar.gz --strip=1 -C ${dir}
-	rm ${dir}/dgr.tar.gz
-	echo $version > $dir/.last_dgr
+  curl --fail --silent --show-error --location "${url}" \
+  | tar --strip=1 -C ${dir}/ -xzv
+  printf "$version" >$dir/.last_dgr
 fi


### PR DESCRIPTION
Avoids requiring both tools.

Please note that no changes have been made to examples or travis*,
because those are not our actual build environment.