### PR TITLE
make early quality checks part of the CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ install:
   - sudo apt-get install -qq upx
   - sudo ./scripts/travis-install-rkt.sh
   - sudo apt-get install -qq bats
+  - go get github.com/gordonklaus/ineffassign
 
 script:
+  - diff <(echo -n) <(gofmt -s -d $(find . -type f -name '*.go' -not -path "./_*" -not -path "./vendor/*"))
+  - ineffassign .
   - ./gomake clean build test quality install
   - sudo PATH=${GOPATH}/bin:$PATH ./examples/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - sudo apt-get install -qq upx
   - sudo ./scripts/travis-install-rkt.sh
   - sudo apt-get install -qq bats
+  - go get github.com/golang/lint/golint
   - go get github.com/gordonklaus/ineffassign
 
 script:
@@ -20,3 +21,8 @@ script:
   - ineffassign .
   - ./gomake clean build test quality install
   - sudo PATH=${GOPATH}/bin:$PATH ./examples/build.sh
+
+after_script:
+  - golint aci-builder
+  - golint bin-templater
+  - golint dgr

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
 script:
   - diff <(echo -n) <(gofmt -s -d $(find . -type f -name '*.go' -not -path "./_*" -not -path "./vendor/*"))
   - ineffassign .
+  - go vet github.com/blablacar/dgr/dgr
+  - go vet github.com/blablacar/dgr/bin-templater
   - ./gomake clean build test quality install
   - sudo PATH=${GOPATH}/bin:$PATH ./examples/build.sh
 


### PR DESCRIPTION
This commit brings *dgr* to current industry best-practices.

There is no point in building a commit that will be discarded later based on these easy to catch formalities.

Output of *golint* is not used to determine if the build succeeded.