### PR TITLE
Fix examples ACI build

### DIFF
--- a/examples/alpine/aci-alpine-base/runlevels/builder/10.build.sh
+++ b/examples/alpine/aci-alpine-base/runlevels/builder/10.build.sh
@@ -4,7 +4,7 @@ set -e
 isLevelEnabled "debug" && set -x
 
 mirror=http://nl.alpinelinux.org/alpine/
-version=2.6.8-r1
+version=2.6.8-r2
 
 wget ${mirror}/latest-stable/main/x86_64/apk-tools-static-${version}.apk
 tar -xzf apk-tools-static-*.apk

--- a/examples/debian/aci-debian-cassandra/runlevels/build/10.install.sh
+++ b/examples/debian/aci-debian-cassandra/runlevels/build/10.install.sh
@@ -20,7 +20,7 @@ gpg --keyserver pgp.mit.edu --recv-keys 0353B12C
 gpg --export --armor 0353B12C | apt-key add -
 
 apt-get update
-apt-get install -y --force-yes cassandra cassandra-tools
+apt-get install -y --force-yes -t jessie-backports cassandra cassandra-tools
 
 chown -R cassandra: /etc/cassandra
 mkdir /data


### PR DESCRIPTION
`cassandra-tools` depend on `openjdk-8-jre-headless` which is only available in `jessie-backports` repo.
Since this is the only version available, it'll be installed:

    apt-cache policy openjdk-8-jre-headless
    openjdk-8-jre-headless:
      Installed: (none)
      Candidate: 8u121-b13-1~bpo8+1
      Version table:
         8u121-b13-1~bpo8+1 0
            100 http://ftp.debian.org/debian/ jessie-backports/main amd64 Packages

`openjdk-8-jre-headless` also depends on `ca-certificates-java` which is available in both official Jessie
repos as well as backports.
Problem is that by default the version from main repo will be privileged for install:

    apt-cache policy ca-certificates-java
    ca-certificates-java:
      Installed: (none)
      Candidate: 20140324
      Version table:
         20161107~bpo8+1 0
            100 http://ftp.debian.org/debian/ jessie-backports/main amd64 Packages
         20140324 0
            500 http://deb.debian.org/debian/ jessie/main amd64 Packages
            500 http://ftp.fr.debian.org/debian/ jessie/main amd64 Packages

Since `openjdk-8-jre-headless` also breaks `ca-certificates-java` version < `20160321` and the choosen version for install will be `20140324`, apt triggers a dependency issue and stop the install.

3 solutions:
1. Use apt pinning (but you take the risk to install all packages from backports which usually you don't want)
2. Specify the exact packages version in apt install command line like
   `apt install openjdk-8-jre-headless=8u121-b13-1~bpo8+1 ca-certificates-java=20161107~bpo8+1`. Works, but version detection can be painfull
3. Force jessie-backports repository usage adding `-t jessie-backports`

I choose the third solution because it's easier ans safer: only needed packages will be picked up from `jessie-backport`