### PR TITLE
Allow specifying builder environments in ACI manifest

### DIFF
--- a/dgr/aci-build.go
+++ b/dgr/aci-build.go
@@ -39,6 +39,10 @@ func (aci *Aci) prepareRktRunArguments(command common.BuilderCommand, builderHas
 	for _, v := range aci.args.SetEnv.Strings() {
 		args = append(args, "--set-env="+v)
 	}
+
+	for _, v := range aci.manifest.Builder.Environment {
+		args = append(args, "--set-env="+v.Name+"="+v.Value)
+	}
 	args = append(args, builderHash)
 	return args
 }

--- a/dgr/common/dgr-manifest.go
+++ b/dgr/common/dgr-manifest.go
@@ -46,9 +46,10 @@ type MountInfo struct {
 }
 
 type BuilderDefinition struct {
-	Image        ACFullname   `json:"image,omitempty" yaml:"image,omitempty"`
-	Dependencies []ACFullname `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
-	MountPoints  []MountInfo  `json:"mountPoints,omitempty" yaml:"mountPoints,omitempty"`
+	Image        ACFullname        `json:"image,omitempty" yaml:"image,omitempty"`
+	Environment  types.Environment `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Dependencies []ACFullname      `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	MountPoints  []MountInfo       `json:"mountPoints,omitempty" yaml:"mountPoints,omitempty"`
 }
 
 type BuildDefinition struct {


### PR DESCRIPTION
This change let's use do something like that:

```YAML
name: aci.github.io/aci-go-app
aci:
  dependencies:
    - aci.github.io/aci-libc
builder:
  dependencies:
    - aci.github.io/aci-builder-go
  environment:
    - { name: GOREPO, value: "github.com/crackcomm/cloudflare/cf" }

```

Specifying builder parameters by specifying environment variables.

