### PR TITLE
examples: cassandra: try getting GPG keys from a second location

### DIFF
--- a/examples/debian/aci-debian-cassandra/runlevels/build/10.install.sh
+++ b/examples/debian/aci-debian-cassandra/runlevels/build/10.install.sh
@@ -10,12 +10,15 @@ deb-src http://www.apache.org/dist/cassandra/debian 30x main
 deb http://ftp.debian.org/debian jessie-backports main
 EOF
 
+gpg --keyserver pool.sks-keyservers.net --recv-keys F758CE318D77295D || \
 gpg --keyserver pgp.mit.edu --recv-keys F758CE318D77295D
 gpg --export --armor F758CE318D77295D | apt-key add -
 
+gpg --keyserver pool.sks-keyservers.net --recv-keys 2B5C1B00 || \
 gpg --keyserver pgp.mit.edu --recv-keys 2B5C1B00
 gpg --export --armor 2B5C1B00 | apt-key add -
 
+gpg --keyserver pool.sks-keyservers.net --recv-keys 0353B12C || \
 gpg --keyserver pgp.mit.edu --recv-keys 0353B12C
 gpg --export --armor 0353B12C | apt-key add -
 


### PR DESCRIPTION
Fixes a build failure that is caused by a timeout when getting the gpg keys.