### PR TITLE
Fix the remote cdebootstrap static dependency version

### DIFF
--- a/examples/debian/aci-debian/runlevels/builder/10.debootstrap.sh
+++ b/examples/debian/aci-debian/runlevels/builder/10.debootstrap.sh
@@ -4,7 +4,7 @@ set -e
 isLevelEnabled "debug" && set -x
 
 keyringFile=debian-archive-keyring_2014.3_all.deb
-cdebootstrapFile=cdebootstrap-static_0.7.6_amd64.deb
+cdebootstrapFile=cdebootstrap-static_0.7.7_amd64.deb
 gpgvFile=gpgv_1.4.18-7+deb8u3_amd64.deb
 
 mkdir /tmp/debootstrap


### PR DESCRIPTION
```
$ curl -LI http://ftp.us.debian.org/debian/pool/main/c/cdebootstrap/cdebootstrap-static_0.7.6_amd64.deb
HTTP/1.1 404 Not Found
Server: nginx/1.11.6
Date: Sat, 11 Mar 2017 11:57:05 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 169
Connection: keep-alive

$ curl -LI http://ftp.us.debian.org/debian/pool/main/c/cdebootstrap/cdebootstrap-static_0.7.7_amd64.deb
HTTP/1.1 200 OK
Server: nginx/1.6.2
Date: Sat, 11 Mar 2017 11:57:12 GMT
Content-Type: application/octet-stream
Content-Length: 454730
Last-Modified: Sun, 05 Mar 2017 12:56:35 GMT
Connection: keep-alive
ETag: "58bc0b03-6f04a"
Accept-Ranges: bytes
```
