### PR TITLE
fix duplicate error message

### DIFF
--- a/aci-builder/bin-run/builder.go
+++ b/aci-builder/bin-run/builder.go
@@ -164,6 +164,10 @@ func (b *Builder) tarAci() error {
 	if err := common.Tar(b.aciTargetPath+common.PathImageAci, common.PathManifest[1:], common.PathRootfs[1:]+"/"); err != nil {
 		return errs.WithEF(err, b.fields, "Failed to tar aci")
 	}
+	// common.ExecCmd sometimes silently fails, hence the redundant check.
+	if _, err := os.Stat(b.aciTargetPath + common.PathImageAci); os.IsNotExist(err) {
+		return errs.WithEF(err, b.fields, "Expected aci has not been created")
+	}
 	logs.WithField("path", dir).Debug("chdir")
 	return nil
 }

--- a/dgr/aci-build.go
+++ b/dgr/aci-build.go
@@ -77,7 +77,7 @@ func (aci *Aci) RunBuilderCommand(command common.BuilderCommand) error {
 
 	content, err := common.ExtractManifestContentFromAci(aci.target + pathImageAci)
 	if err != nil {
-		logs.WithEF(err, aci.fields).Warn("Failed to write manifest.json")
+		logs.WithEF(err, aci.fields).Warn("Failed to extract manifest.json")
 	}
 
 	if err := ioutil.WriteFile(aci.target+pathManifestJson, content, 0644); err != nil {


### PR DESCRIPTION
I ran into this when developing the *reproducible builds* feature.

An additional error message will be emitted if tar didn't return an error, but the tarball were still missing. Which can happen on network shares and some *fuse* filesystems. Ran into this, too.