### PR TITLE
[aci-tester] - Fix issue with aci without bash s/bash/busybox/

### DIFF
--- a/aci-tester/files/dgr/test-builder/stage2/test.tmpl
+++ b/aci-tester/files/dgr/test-builder/stage2/test.tmpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/dgr/bin/busybox sh
 
 /dgr/bin/busybox --install &> /dev/null
 

--- a/aci-tester/files/dgr/usr/bin/test.sh
+++ b/aci-tester/files/dgr/usr/bin/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/dgr/bin/busybox sh
 . /dgr/bin/functions.sh
 isLevelEnabled "debug" && set -x
 


### PR DESCRIPTION
Fix issue where the tested aci use a bash not staticaly linked , and the lib directory is removed / replaced by the flattening of dependencies.