### PR TITLE
Add environment variable when running dgr test

### DIFF
--- a/dgr/aci-test.go
+++ b/dgr/aci-test.go
@@ -90,6 +90,7 @@ func (aci *Aci) runTestAci(testerHash string, hashAcis []string) error {
 
 	defer aci.cleanupTest(testerHash, hashAcis)
 	if err := Home.Rkt.Run([]string{"--set-env=" + common.EnvLogLevel + "=" + logs.GetLevel().String(),
+		"--set-env=TESTER=TRUE",
 		"--net=default",
 		"--mds-register=false",
 		"--uuid-file-save=" + aci.target + pathTesterUuid,


### PR DESCRIPTION
When using `dgr test` it'll be convenient to have a simple to check if we are currently running in a test environment, so we can avoid execution of runlevels step during testing

(In addition of #250 )