### PR TITLE
Export TemplateFile's RunTemplate()

### DIFF
--- a/bin-templater/template/directory.go
+++ b/bin-templater/template/directory.go
@@ -115,7 +115,7 @@ func (t *TemplateDir) processSingleDir(src string, dst string, attributes map[st
 			if err != nil {
 				return err
 			}
-			if err2 := template.runTemplate(dstObj, attributes, !t.continueOnError); err2 != nil {
+			if err2 := template.RunTemplate(dstObj, attributes, !t.continueOnError); err2 != nil {
 				if t.continueOnError {
 					err = err2
 					logs.WithEF(err, t.fields).Error("Templating failed")

--- a/bin-templater/template/file.go
+++ b/bin-templater/template/file.go
@@ -66,7 +66,7 @@ func (t *TemplateFile) loadTemplateConfig(src string) error {
 	return nil
 }
 
-func (f *TemplateFile) runTemplate(dst string, attributes map[string]interface{}, failOnNoValue bool) error {
+func (f *TemplateFile) RunTemplate(dst string, attributes map[string]interface{}, failOnNoValue bool) error {
 	if logs.IsTraceEnabled() {
 		logs.WithF(f.fields).WithField("attributes", attributes).WithField("failOnNoValue", failOnNoValue).Trace("templating with attributes")
 	}


### PR DESCRIPTION
On other tools that vendore the bin-templater engine such as  [ggn](https://github.com/blablacar/ggn), we want to render template on single file, not only on while directories.
This PR makes that possible.