### PR TITLE
[aci-tester] switch to maintained bats-core v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,22 @@ sudo: required
 dist: trusty
 
 go:
- - 1.8
+ - "1.12.9"
 
 install:
   - sudo rm -rf /var/lib/apt/lists/*
-  - sudo add-apt-repository ppa:duggan/bats --yes
   - sudo add-apt-repository ppa:pitti/systemd --yes
   - sudo apt-get update -qq
   - sudo apt-get install -qq upx systemd
   - sudo ./scripts/travis-install-rkt.sh
-  - sudo apt-get install -qq bats
+  - npm -g install bats
 
 script:
-  - ./gomake clean build test quality install
+  - ./gomake clean
+  - ./gomake build
+  - ./gomake test
+  - ./gomake quality
+  - ./gomake install
   - mkdir -p ~/.config/dgr
   - 'echo -e "rkt:\n pullPolicy: new" > ~/.config/dgr/config.yml'
   - sudo PATH=${GOPATH}/bin:$PATH ./examples/build.sh

--- a/aci-tester/build.sh
+++ b/aci-tester/build.sh
@@ -11,7 +11,9 @@ mkdir -p ${rootfs}/dgr/usr/bin ${rootfs}/dgr/usr/lib
 cp -R ${dir}/files/. ${rootfs}/
 cp ${dir}/manifest.json ${target}/manifest
 
-: ${bats_src:="https://raw.githubusercontent.com/sstephenson/bats/master/libexec"}
+BATS_VERSION="v1.1.0"
+
+: ${bats_src:="https://raw.githubusercontent.com/bats-core/bats-core/${BATS_VERSION}/libexec/bats-core"}
 curl --fail --silent --show-error --location --remote-time --compressed --create-dirs \
     {-z,-o}"${rootfs}/dgr/usr/bin/bats" \
     ${bats_src}/bats

--- a/examples/alpine/aci-alpine-base/runlevels/builder/10.build.sh
+++ b/examples/alpine/aci-alpine-base/runlevels/builder/10.build.sh
@@ -3,8 +3,8 @@ set -e
 . /dgr/bin/functions.sh
 isLevelEnabled "debug" && set -x
 
-mirror=http://nl.alpinelinux.org/alpine/
-version=2.9.1-r2
+mirror=http://nl.alpinelinux.org/alpine
+version=2.10.4-r2
 
 wget ${mirror}/latest-stable/main/x86_64/apk-tools-static-${version}.apk
 tar -xzf apk-tools-static-*.apk

--- a/examples/debian/aci-debian-cassandra/runlevels/build/10.install.sh
+++ b/examples/debian/aci-debian-cassandra/runlevels/build/10.install.sh
@@ -7,7 +7,7 @@ cat > /etc/apt/sources.list.d/cassandra.list<<EOF
 deb http://ftp.fr.debian.org/debian/ jessie main non-free contrib # needed for java8
 deb http://www.apache.org/dist/cassandra/debian 30x main
 deb-src http://www.apache.org/dist/cassandra/debian 30x main
-deb http://ftp.debian.org/debian jessie-backports main
+deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main
 EOF
 
 gpg --keyserver pool.sks-keyservers.net --recv-keys F758CE318D77295D || \
@@ -22,8 +22,12 @@ gpg --keyserver pool.sks-keyservers.net --recv-keys 0353B12C || \
 gpg --keyserver pgp.mit.edu --recv-keys 0353B12C
 gpg --export --armor 0353B12C | apt-key add -
 
-apt-get update
-apt-get install -y --force-yes -t jessie-backports cassandra cassandra-tools
+# For Cassandra
+apt-key adv --keyserver pool.sks-keyservers.net --recv-key A278B781FE4B2BDA
+
+# Jessie is too old, so we add `-o Acquire::Check-Valid-Until=false` (for now)
+apt-get -o Acquire::Check-Valid-Until=false update
+apt-get -o Acquire::Check-Valid-Until=false install -y --force-yes -t jessie-backports cassandra cassandra-tools
 
 chown -R cassandra: /etc/cassandra
 mkdir /data

--- a/examples/debian/aci-debian/runlevels/builder/10.debootstrap.sh
+++ b/examples/debian/aci-debian/runlevels/builder/10.debootstrap.sh
@@ -3,9 +3,9 @@ set -e
 . /dgr/bin/functions.sh
 isLevelEnabled "debug" && set -x
 
-keyringFile=debian-archive-keyring_2014.3_all.deb
+keyringFile=debian-archive-keyring_2017.5_all.deb
 cdebootstrapFile=cdebootstrap-static_0.7.7+b1_amd64.deb
-gpgvFile=gpgv_1.4.18-7+deb8u4_amd64.deb
+gpgvFile=gpgv_1.4.18-7+deb8u5_amd64.deb
 
 mkdir /tmp/debootstrap
 cd /tmp/debootstrap

--- a/examples/debian/aci-debian/runlevels/inherit-build-early/00.apt-get-update.sh
+++ b/examples/debian/aci-debian/runlevels/inherit-build-early/00.apt-get-update.sh
@@ -3,4 +3,5 @@ set -e
 . /dgr/bin/functions.sh
 isLevelEnabled "debug" && set -x
 
-apt-get update
+# Jessie is too old, so we add `-o Acquire::Check-Valid-Until=false` (for now)
+apt-get -o Acquire::Check-Valid-Until=false update

--- a/examples/gentoo/aci-gentoo-stage4/runlevels/builder/10.prepare.sh
+++ b/examples/gentoo/aci-gentoo-stage4/runlevels/builder/10.prepare.sh
@@ -4,7 +4,7 @@ set -e
 isLevelEnabled "debug" && set -x
 
 ###############################################################################
-gentoo_mirror="http://gentoo.mirrors.ovh.net/gentoo-distfiles/"
+gentoo_mirror="http://gentoo.mirrors.ovh.net/gentoo-distfiles"
 ###############################################################################
 
 stage4=$(curl --silent ${gentoo_mirror}/releases/amd64/autobuilds/latest-stage4-amd64-minimal.txt | grep -v "^#" | egrep "stage4-amd64-minimal" | cut -d' ' -f 1 )
@@ -36,4 +36,4 @@ done
 
 echo_green "Extracting stage4"
 #TODO builder is missing libacl-devel, libattr-devel, and libselinux-devel for tar to support xattrs
-tar xjpf ${stage4tarball} -C "${ROOTFS}" --xattrs
+tar xJpf ${stage4tarball} -C "${ROOTFS}" --xattrs

--- a/gomake
+++ b/gomake
@@ -157,7 +157,7 @@ quality() {
     fi
 
     echo_green "Lint"
-    command -v golint > /dev/null || go get -u github.com/golang/lint/golint
+    command -v golint > /dev/null || go get -u golang.org/x/lint/golint
     for i in ${go_files}; do
         golint ${i} | grep -v 'should have comment ' || true
     done

--- a/scripts/travis-install-rkt.sh
+++ b/scripts/travis-install-rkt.sh
@@ -2,7 +2,7 @@
 set -x
 set -e
 
-version="v1.28.0"
+version="v1.30.0"
 filename="rkt-${version}.tar.gz"
 url="https://github.com/rkt/rkt/releases/download/${version}/${filename}"
 


### PR DESCRIPTION
The bats project has moved to bats-core and has recieved several
backwards-compatible fixes in its newer versions. These updates may fix
some of the issues with hanging tests and other bad or otherwise flaky
behavior.